### PR TITLE
allow disabling docs with pydantic

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,12 +1,21 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from pydantic_settings import BaseSettings
 
 from app.MyLogger import logger
 from app.routers.dogfinder import router as dogfinder_router
 import os
 
+
+class Settings(BaseSettings):
+    openapi_url: str = "/openapi.json"
+
+
+settings = Settings()
+
+app = FastAPI(openapi_url=settings.openapi_url)
+
 logger.info("Starting up the app")
-app = FastAPI()
 
 origins = [f"{os.environ.get('ALLOWED_CORS', 'https://localhost:3000')}"]
 


### PR DESCRIPTION
https://fastapi.tiangolo.com/advanced/settings/
https://testdriven.io/tips/80107066-795c-4026-b7df-e250cdcd3dac/
after this is in we can disable exposing the /docs in production with an env var `OPENAPI_URL=""`