### PR TITLE
fix: docker compose file

### DIFF
--- a/dogfinder-docker-compose.yml
+++ b/dogfinder-docker-compose.yml
@@ -31,9 +31,7 @@ services:
     - 0.0.0.0
     - --port
     - '8000'
-    build:
-      context: .
-      dockerfile: Dockerfile-dev
+    image: dogfinder:latest
     ports:
     - 8000:8000
     restart: on-failure:0


### PR DESCRIPTION
Fix docker-compose file. We will use a different command in mac and in windows for building the image and using it before the docker compose. 
In windows:
`docker build --pull --rm -f "Dockerfile" -t dogfinder:latest "."`

In mac:
`docker buildx build --platform=linux/amd64 --pull --rm -f "Dockerfile" -t dogfinder:latest "."`