### PR TITLE
fix: auth0 config & authorization

### DIFF
--- a/.config
+++ b/.config
@@ -1,5 +1,0 @@
-[AUTH0]
-DOMAIN = dog-finder.eu.auth0.com
-API_AUDIENCE = https://galzo.github.io/dog-finder/
-ALGORITHMS = RS256
-ISSUER = https://dog-finder.eu.auth0.com/

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,4 @@ RUN python -c 'from sentence_transformers import SentenceTransformer; embedder =
 
 # copy the folder app including to the container without any other folders
 COPY app app
-COPY .config .
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -22,5 +22,4 @@ RUN python -c 'from sentence_transformers import SentenceTransformer; embedder =
 
 # copy the folder app including to the container without any other folders
 COPY app app
-COPY .config .
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/routers/dogfinder.py
+++ b/app/routers/dogfinder.py
@@ -209,7 +209,7 @@ auth = VerifyToken()
 #         # return back a json response and set the status code to api_response.status_code
 #         return JSONResponse(content=api_response.to_dict(), status_code=api_response.status_code)
 
-@router.post("/search_in_found_dogs/", response_model=APIResponse)
+@router.post("/search_in_found_dogs", response_model=APIResponse)
 async def search_in_found_dogs(dogSearchRequest: DogSearchRequest):
     try:
         # Handle the image, resize it and convert it to base64 with webp format and get the content type
@@ -231,7 +231,7 @@ async def search_in_found_dogs(dogSearchRequest: DogSearchRequest):
         # return back a json response and set the status code to api_response.status_code
         return JSONResponse(content=api_response.to_dict(), status_code=api_response.status_code)
 
-@router.post("/search_in_lost_dogs/", response_model=APIResponse)
+@router.post("/search_in_lost_dogs", response_model=APIResponse)
 async def search_in_lost_dogs(dogSearchRequest: DogSearchRequest):
     try:
         # Handle the image, resize it and convert it to base64 with webp format and get the content type
@@ -254,7 +254,7 @@ async def search_in_lost_dogs(dogSearchRequest: DogSearchRequest):
         # return back a json response and set the status code to api_response.status_code
         return JSONResponse(content=api_response.to_dict(), status_code=api_response.status_code)
 
-@router.get("/get_unverified_documents/", response_model=APIResponse)
+@router.get("/get_unverified_documents", response_model=APIResponse)
 async def get_unverified_documents(auth_result: str = Security(auth.verify, scopes=['read:unverified_documents'])):
     try:
         # Query the database
@@ -269,7 +269,7 @@ async def get_unverified_documents(auth_result: str = Security(auth.verify, scop
         return JSONResponse(content=api_response.to_dict(), status_code=api_response.status_code)
     
 # Endpoint for quering the database without the need for a query image, only DOG_ID_FIELD
-@router.get("/get_dog_by_id/", response_model=APIResponse)
+@router.get("/get_dog_by_id", response_model=APIResponse)
 async def get_dog_by_id(dogId: int):
     try:
         # Query the database
@@ -287,8 +287,8 @@ async def get_dog_by_id(dogId: int):
         return JSONResponse(content=api_response.to_dict(), status_code=api_response.status_code)
 
 # Endpoint for quering the database without the need for a query image, only DOG_ID_FIELD
-@router.get("/get_dog_by_id_full_details/", response_model=APIResponse)
-async def query_by_dog_id(dogId: int, auth_result: str = Security(auth.verify, scopes=['read:dogs:by_id'])):
+@router.get("/get_dog_by_id_full_details", response_model=APIResponse)
+async def query_by_dog_id(dogId: int, auth_result: str = Security(auth.verify, scopes=['read:get_dog_by_id_full_details'])):
     try:
         # Query the database
         dog = dogWithImagesRepository.get_dog_with_images_by_id(dogId)
@@ -442,7 +442,7 @@ async def clean_all():
     return JSONResponse(content=api_response.to_dict(), status_code=api_response.status_code)
 
 @router.post("/doc_matched", response_model=APIResponse)
-async def doc_matched(foundRequest: DogMatchedRequest):
+async def doc_matched(foundRequest: DogMatchedRequest, auth_result: str = Security(auth.verify, scopes=['write:dog_matched'])):
 
     result = dogWithImagesService.update_dog_is_matched(foundRequest.dogId, True)
 

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -1,4 +1,3 @@
-from configparser import ConfigParser
 import os
 from typing import Optional
 
@@ -9,20 +8,13 @@ from fastapi.security import SecurityScopes, HTTPAuthorizationCredentials, HTTPB
 def get_auth0_config():
     """Sets up configuration for the app"""
 
-    env = os.getenv("ENV", ".config")
-
-    # Read config from .config file or environment variables
-    if env == ".config":
-        config = ConfigParser()
-        config.read(".config")
-        config = config["AUTH0"]
-    else:
-        config = {
-            "DOMAIN": os.getenv("AUTH0_DOMAIN"),
-            "API_AUDIENCE": os.getenv("AUTH0_API_AUDIENCE"),
-            "ISSUER": os.getenv("AUTH0_ISSUER"),
-            "ALGORITHMS": os.getenv("AUTH0_ALGORITHMS"),
-        }
+    config = {
+        "DOMAIN": os.getenv("AUTH0_DOMAIN"),
+        "API_AUDIENCE": os.getenv("AUTH0_API_AUDIENCE"),
+        "ISSUER": os.getenv("AUTH0_ISSUER"),
+        "ALGORITHMS": os.getenv("AUTH0_ALGORITHMS"),
+    }
+        
     for key, value in config.items():
         if value == "":
             print(f"Missing config: {key}")

--- a/dogfinder-docker-compose.dev.yml
+++ b/dogfinder-docker-compose.dev.yml
@@ -32,6 +32,10 @@ services:
     - --port
     - '8000'
     image: dogfinder:latest
+    build: 
+      context: .
+      platforms:
+        - "linux/amd64"
     ports:
     - 8000:8000
     restart: on-failure:0

--- a/env_vars/.env.development
+++ b/env_vars/.env.development
@@ -1,0 +1,9 @@
+AI_MODULES='dogfinder'
+WEAVIATE_HOST='http://weaviate:8080'
+SENTENCE_TRANSFORMER_EMBEDDING_MODEL_NAME='clip-ViT-B-32'
+ALLOWED_CORS='*'
+# AUTH0
+DOMAIN=dog-finder-dev.eu.auth0.com
+API_AUDIENCE=http://localhost:8000
+ALGORITHMS=RS256
+ISSUER=https://dog-finder-dev.eu.auth0.com/


### PR DESCRIPTION
A few changes here:
###  Fix auth0 config
 I separated the environments of development and production. For this I had to make changes in docker-compose and created another .dev.yaml file.

Now, in order to build the image: 
#### in mac
`docker compose -f dogfinder-docker-compose.dev.yml build`

And then run
`docker compose -f dogfinder-docker-compose.dev.yml up --no-build`
You can supply the `-d` to detach

#### in windows
`docker build --no-cache  --pull --rm -f "Dockerfile" -t dogfinder:latest "."`

And then to run it:
`docker compose -f dogfinder-docker-compose.dev.yml up --no-build`

### Fix inconsistency with routes

Some of the routes had a trailing `/` and some didn't. Since the REST convention is not to use the trailing `/` I just removed it from some of the routes

![Screenshot 2023-10-28 at 18 45 52](https://github.com/NirDiamant/dog_finder/assets/80447963/a31fcca6-2fd3-44fd-9180-9efce5000127)
