### PR TITLE
Update requirements.txt - add psycopg2 for postgres

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ Pillow
 sentence_transformers
 sqlalchemy
 sqlalchemy_utils
+psycopg2


### PR DESCRIPTION
```
dogfinder-app
File "/usr/local/lib/python3.11/site-packages/sqlalchemy/dialects/postgresql/psycopg2.py", line 690, in import_dbapi
dogfinder-app
import psycopg2
dogfinder-app
ModuleNotFoundError: No module named 'psycopg2'
dogfinder-app
ERROR: Application startup failed. Exiting.
```
when using `postgresql` as the `DB_PROTOCOL`