### PR TITLE
add reporter id & some reafctoring

### DIFF
--- a/app/DAL/models.py
+++ b/app/DAL/models.py
@@ -17,6 +17,7 @@ class Dog(Base):
     # Dog data
     ## Entry data
     id = Column(Integer, primary_key=True, autoincrement=True)
+    reporterId = Column(String)
     type = Column(DOG_TYPE_ENUMS, nullable=False) # vectordb will use this field DO NOT REMOVE
     isMatched = Column(Boolean, default=False)
     isVerified = Column(Boolean, default=False)

--- a/app/DTO/dog_dto.py
+++ b/app/DTO/dog_dto.py
@@ -18,6 +18,7 @@ class DogImageDTO(BaseModel):
 
 class DogDTO(BaseModel):
     id: Optional[int] = None
+    reporterId: str 
     images: List[DogImageDTO]
     type: DogType
     isMatched: bool = False

--- a/app/MyLogger.py
+++ b/app/MyLogger.py
@@ -17,10 +17,11 @@ console = logging.StreamHandler()
 console.setFormatter(fmt)
 logger.addHandler(console)
 
-if (os.path.exists("/var/log/")):
+if (os.path.exists(os.getenv("LOGGER_ROOT_PATH"))):
     # create folder if it doesn't exist
-    if not os.path.exists("/var/log/dogfinder"):
-        os.makedirs("/var/log/dogfinder")
-    fileHandler = RotatingFileHandler('/var/log/dogfinder/dogfinder.log', maxBytes=10000000, backupCount=5)
+    logger_app_path = f"{os.getenv('LOGGER_ROOT_PATH')}/dogfinder"
+    if not os.path.exists(logger_app_path):
+        os.makedirs(logger_app_path)
+    fileHandler = RotatingFileHandler(f"{logger_app_path}/dogfinder.log", maxBytes=10000000, backupCount=5)
     fileHandler.setFormatter(fmt)
     logger.addHandler(fileHandler)

--- a/app/exceptions/auth_exceptions.py
+++ b/app/exceptions/auth_exceptions.py
@@ -1,0 +1,18 @@
+from fastapi import HTTPException, status
+
+
+class AuthException(HTTPException):
+    pass
+
+
+class UnauthorizedException(AuthException):
+    def __init__(self, detail: str, **kwargs):
+        """Returns HTTP 403"""
+        super().__init__(status.HTTP_403_FORBIDDEN, detail=detail)
+
+
+class UnauthenticatedException(AuthException):
+    def __init__(self):
+        super().__init__(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Requires authentication"
+        )

--- a/app/init/exception_handler.py
+++ b/app/init/exception_handler.py
@@ -1,0 +1,35 @@
+import logging
+from fastapi import FastAPI, HTTPException, Request, status
+from fastapi.responses import JSONResponse
+
+from app.exceptions.auth_exceptions import AuthException
+from app.viewmodels.api_response import APIResponse
+
+logger = logging.getLogger(__name__)
+
+def setup_exacption_handler(app: FastAPI):
+    
+    
+    @app.exception_handler(AuthException)
+    def handle_auth_exception(_, e: AuthException):
+        e_message = e.detail
+        logger.warning("Some error occurred during authentication/authorization: %s", e_message, exc_info=e)
+        api_response = APIResponse(status_code=e.status_code, message = e_message)
+        return JSONResponse(api_response.to_dict(), status_code=api_response.status_code)
+    
+    
+    @app.exception_handler(HTTPException)
+    def handle_http_exception(request: Request, e: HTTPException):
+        e_message = e.detail
+        logger.exception("Something bad happend during request %s: %s", request.url, e_message, exc_info=e)
+        api_response = APIResponse(status_code=e.status_code, message=e_message)
+        return JSONResponse(api_response.to_dict(), status_code=api_response.status_code)
+        
+    
+    @app.exception_handler(Exception)
+    def handle_exception(_, e: Exception):
+        logger.exception("An error eccured: %s", e, exc_info=e)
+        api_response = APIResponse(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, message="Internal Error")
+        return JSONResponse(api_response.to_dict(), status_code=api_response.status_code)
+    
+    

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from app.init.exception_handler import setup_exacption_handler
 from pydantic_settings import BaseSettings
 
 from app.MyLogger import logger
@@ -19,6 +20,7 @@ logger.info("Starting up the app")
 
 origins = [f"{os.environ.get('ALLOWED_CORS', 'https://localhost:3000')}"]
 
+setup_exacption_handler(app)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,

--- a/app/routers/dogfinder.py
+++ b/app/routers/dogfinder.py
@@ -317,7 +317,7 @@ async def add_document(dogRequest: DogAddRequest, auth_result: dict = Security(a
         # Create DogDocument
         # Map the DogRequest to DogDTO
         dogDTO = mapper.to(DogDTO).map(dogRequest, fields_mapping={
-            "images": [], "reporterId": auth_result["azp"]
+            "images": [], "reporterId": auth_result["sub"]
         })
         dogDTO.images = [DogImageDTO(base64Image=base64Image[0], imageContentType=base64Image[1]) for base64Image in base64Images]
 

--- a/app/viewmodels/dog_viewmodel.py
+++ b/app/viewmodels/dog_viewmodel.py
@@ -75,6 +75,7 @@ class DogImageResponse(BaseModel):
 
 class DogResponse(BaseModel):
     id: int
+    reporterId: str
     images: List[DogImageResponse]
     type: DogType
     isMatched: bool = False

--- a/env_vars/.env.development
+++ b/env_vars/.env.development
@@ -3,7 +3,9 @@ WEAVIATE_HOST='http://weaviate:8080'
 SENTENCE_TRANSFORMER_EMBEDDING_MODEL_NAME='clip-ViT-B-32'
 ALLOWED_CORS='*'
 # AUTH0
-DOMAIN=dog-finder-dev.eu.auth0.com
-API_AUDIENCE=http://localhost:8000
-ALGORITHMS=RS256
-ISSUER=https://dog-finder-dev.eu.auth0.com/
+AUTH0_DOMAIN=dog-finder-dev.eu.auth0.com
+AUTH0_API_AUDIENCE=http://localhost:8000
+AUTH0_ISSUER=https://dog-finder-dev.eu.auth0.com/
+AUTH0_ALGORITHMS=RS256
+# LOGGER
+LOGGER_ROOT_PATH=/var/log/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fastapi
 uvicorn
-PyJWT
+pyjwt[crypto]
 cachetools
 python-multipart
 pydantic-settings


### PR DESCRIPTION
* Added reporter_id - this is coming from the "sub" property in `auth_result` This corresponds to the complete id in auth 0, which includes the connection type, as seen here:
<img width="1017" alt="Screenshot 2023-10-31 at 22 41 21" src="https://github.com/NirDiamant/dog_finder/assets/80447963/ac7bf3b6-8931-465c-91cc-c3ce1a12d196">

@YanDav78 I'm wondering if we should clean the `google-oauth2|` from the string or that it doesn't really matter. As you can see the `user_id` for them is the `user_id` and the connection type. A recursive definition. 

*Added exception_handler to main. This intercepts all uncaught exceptions from the application and wraps them. We could also clean the endpoints like this, but I didn't touch them for now.
