### PR TITLE
fix: convert empty strings to nulls

### DIFF
--- a/app/viewmodels/dog_viewmodel.py
+++ b/app/viewmodels/dog_viewmodel.py
@@ -87,7 +87,7 @@ class DogAddRequest(BaseModel):
     class Config:
         use_enum_values = True
         
-    @validator("*", pre=True)
+    @validator("sex", pre=True)
     def empty_strings_to_none(cls, value):
         if isinstance(value, str) and not value:
             return None

--- a/app/viewmodels/dog_viewmodel.py
+++ b/app/viewmodels/dog_viewmodel.py
@@ -1,7 +1,7 @@
 from datetime import date
 from enum import Enum
 from typing import List, Optional
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel, field_serializer, validator
 
 RETURN_PROPERTIES = [
     "type",
@@ -86,6 +86,13 @@ class DogAddRequest(BaseModel):
     
     class Config:
         use_enum_values = True
+        
+    @validator("*", pre=True)
+    def empty_strings_to_none(cls, value):
+        if isinstance(value, str) and not value:
+            return None
+        return value
+    
 
 class DogImageResponse(BaseModel):
     id: int


### PR DESCRIPTION
When sending `add_document` request from the frontend, empty values are sent as empty strings, and the BE doesn't know how to deal with it for the dog's sex, because it expects either an enum/None. I figured it would just be easier to clean all empty string values to `None` - so it would also be easier to query the DB for empty values if needed. @YanDav78 if you disagree tell me. I can just make this validator specifically for the `sex` field. 